### PR TITLE
fix: 453 comes before 452 in sort order

### DIFF
--- a/_posts/2025-02-18-LHAHS452.md
+++ b/_posts/2025-02-18-LHAHS452.md
@@ -4,7 +4,7 @@ title: "Chapter 452"
 comments: true
 tags: [lhahs]
 categories: [lhahs]
-date: 2025-02-18 22:21:00 +0800
+date: 2025-02-18 21:24:00 +0800
 ---
 
 Hyper Perception was a power Aaron had possessed since birth, allowing him to perceive things others could not. When activated, it granted him a near-precognitive ability, letting him grasp events before they happened.

--- a/_posts/2025-02-18-LHAHS453.md
+++ b/_posts/2025-02-18-LHAHS453.md
@@ -4,7 +4,7 @@ title: "Chapter 453"
 comments: true
 tags: [lhahs]
 categories: [lhahs]
-date: 2025-02-18 21:24:00 +0800
+date: 2025-02-18 22:21:00 +0800
 ---
 
 While Aru's face remained clouded with unease...


### PR DESCRIPTION
This PR fixes a small continuity error with chapters 452 and 453 where they are swapped in the ordering.
![image](https://github.com/user-attachments/assets/79e3b5e1-31c6-4781-ba6c-d0322a839a71)

I simply swapped their date fields so that they would sort properly.